### PR TITLE
display error message to user

### DIFF
--- a/trip-advisori-iOS/AmbassadorOfTheAPI.swift
+++ b/trip-advisori-iOS/AmbassadorOfTheAPI.swift
@@ -103,26 +103,28 @@ class AmbassadorToTheAPI: NSObject {
     }
     
     func processResponse(_ response: DataResponse<Any>, success: @escaping NetworkSuccessHandler, uri: URLConvertible) {
-        if response.result.isFailure {
-            if let res = response.response {
-                if res.statusCode == 401 {
-                    self.refreshToken(uri, success: success)
-                } else {
-                    
-                }
-            } else {
-                createNoInternetWarning()
-            }
+        let status = response.response!.statusCode
+        if (response.result.isFailure) && (status == 401) {
+            self.refreshToken(uri, success: success)
+        } else if (status / 100 != 2) {
+            displayError(response)
         } else {
             success(response)
         }
     }
     
-    func createNoInternetWarning() {
+    func displayError(_ response: DataResponse<Any>) {
         let topView = UIApplication.topViewController()!.view
         let label = UILabel(frame: CGRect(x: 0, y: (topView?.frame.height)! - 40, width: (topView?.frame.width)!, height: 40))
         label.textAlignment = NSTextAlignment.center
-        label.text = "No Internet Connectivity"
+        
+        let JSON = response.result.value as! NSDictionary
+        if let message = JSON["message"] {
+            label.text = message as? String
+        } else {
+            label.text = "No Internet Connectivity"
+        }
+        
         label.font = UIFont(name: Fonts.dosisBold, size: 16)
         label.textColor = UIColor.white
         label.backgroundColor = UIColor.basePurple


### PR DESCRIPTION
So apparently alamofire considers all successfully completed requests as "successful", so even 400 and 500 level errors were taking the happy path. So I changed it so that the "success" callback is only executed if the status code at the 200 level.

Also changed it to display the error message directly to the user. Eventually we might not want to do that, but for now it will give us insight into exactly what went wrong on the server side.